### PR TITLE
Fix variable names in README.md cue section

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ The cue is displayed immediately before where the user types.
 
 | Option                    | Default  | Description |
 |---------------------------|----------|-------------|
-| `vertical_vert_cue`       | `' '`    | Cue text    |
-| `vertical_vert_cue_color` | `normal` | Cue color   |
+| `vertical_cue`       | `' '`    | Cue text    |
+| `vertical_cue_color` | `normal` | Cue color   |
 
 ### Directory
 

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ The cue is displayed immediately before where the user types.
 
 | Option                    | Default  | Description |
 |---------------------------|----------|-------------|
-| `vertical_cue`       | `' '`    | Cue text    |
-| `vertical_cue_color` | `normal` | Cue color   |
+| `vertical_cue`            | `' '`    | Cue text    |
+| `vertical_cue_color`      | `normal` | Cue color   |
 
 ### Directory
 


### PR DESCRIPTION
Setting `vertical_vert_cue` and `vertical_vert_cue_color` do not work, but `vertical_cue` and `vertical_cue_color` do.

Just a tiny detail to correct. I was struggling to figure out why it wasn't working and I almost filed an issue, but this fix is easiest.

Big fan of this prompt, by the way. I tried just about all of them but this is the only one that I wanted to keep.